### PR TITLE
[strings.xml] capitalize completed

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -280,13 +280,13 @@
     <string name="copy_to_clipboard">copy to clipboard</string>
     <string name="success">Successes!</string>
     <string name="failed">failed!</string>
-    <string name="clear_all_preference">clear all application settings</string>
+    <string name="clear_all_preference">Clear all application settings</string>
     <string name="clear_all_preference_msg"><b>Warning</b>: this will reset <b>ALL</b> app preferences/settings! \n\nThis might be very helpful if application crashes on launching. \nAre you sure?</string>
     <string name="failed_to_delete">Failed to delete</string>
     <string name="grant_permission">Grant Permission</string>
     <string name="retry">Retry</string>
     <string name="permission_manage_external_storage_denied">it seems that Phonograph has no permission \"manage external storage\"!</string>
-    <string name="not_available_now">not available now</string>
+    <string name="not_available_now">Not available now</string>
     <string name="check_upgrade">Check upgrade</string>
     <string name="no_newer_version">No update!</string>
     <string name="new_version">New Version!</string>
@@ -416,7 +416,7 @@
     <string name="delete_with_lyrics">Delete with lyrics</string>
     <string name="excluded_paths">Excluded Paths</string>
     <string name="included_paths">Included Paths</string>
-    <string name="swith_mode">switch mode</string>
+    <string name="swith_mode">Switch mode</string>
     <string name="path_filter">Path Filter</string>
     <string name="path_filter_excluded_mode">Exclude Mode</string>
     <string name="path_filter_included_mode">Include Mode</string>
@@ -455,5 +455,5 @@
     <string name="permission_desc_read_media_audio">Since Android T (13), application with this permission can read audios of the device.</string>
     <string name="permission_name_read_external_storage">Read External Storage</string>
     <string name="permission_desc_read_external_storage">Read External Storage permission is required to read music file in the device.</string>
-    <string name="completed">completed</string>
+    <string name="completed">Completed</string>
 </resources>


### PR DESCRIPTION
Capitalize the first letter of some strings, so that it looks more clean.

I also maybe wanted to improve the "IMPORT:SETTINGS" string in the App Intro, but I was unable to understand how it was "constructed".
Same goes from the import/export in menus, or the "read the contents of your SD card" string on the bottom banner if permission wasn't granted.
The comment under "Path Filter" could maybe also be improved, as the line ending with a dash looks strange.

I also found some strings missing capitals but I don't know where are they used, if it's normal.