### PR TITLE
Sort albums under artist by year ascending.

### DIFF
--- a/app/src/main/java/player/phonograph/repo/mediastore/internal/AlbumCataloger.kt
+++ b/app/src/main/java/player/phonograph/repo/mediastore/internal/AlbumCataloger.kt
@@ -89,7 +89,7 @@ suspend fun catalogAlbums(songs: List<Song>): Deferred<List<Album>> = coroutineS
             createAlbum(id, list)
         }.catch { e ->
             reportError(e, TAG_ALBUM, "Fail to load albums")
-        }.toList().sortAllAlbums(SortMode(SortRef.YEAR, true))
+        }.toList().sortAllAlbums(SortMode(SortRef.YEAR, false))
     }
 }
 


### PR DESCRIPTION
Sorting albums by year of release in ascending order is more natural than descending.