### PR TITLE
Added .idea's files and folders in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,18 +47,3 @@ products/**/mapping.txt
 products/
 
 GitHubReleaseNote.url.txt
-
-# Idea file/folder those are not tracked.
-.idea/other.xml
-.idea/appInsightsSettings.xml
-.idea/compiler.xml
-.idea/copyright
-.idea/modules
-.idea/deploymentTargetDropDown.xml
-.idea/deploymentTargetSelector.xml
-.idea/encodings.xml
-.idea/workspace.xml
-.idea/kotlinc.xml
-.idea/gradle.xml
-.idea/vcs.xml
-.idea/misc.xml

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,18 @@ products/**/mapping.txt
 products/
 
 GitHubReleaseNote.url.txt
+
+# Idea file/folder those are not tracked.
+.idea/other.xml
+.idea/appInsightsSettings.xml
+.idea/compiler.xml
+.idea/copyright
+.idea/modules
+.idea/deploymentTargetDropDown.xml
+.idea/deploymentTargetSelector.xml
+.idea/encodings.xml
+.idea/workspace.xml
+.idea/kotlinc.xml
+.idea/gradle.xml
+.idea/vcs.xml
+.idea/misc.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -18,3 +18,7 @@ workspace.xml
 compiler.xml
 deploymentTargetDropDown.xml
 deploymentTargetSelector.xml
+appInsightsSettings.xml
+encodings.xml
+copyright
+other.xml


### PR DESCRIPTION
Reason to add idea file in gitIgnore is 
Idea file and folder are generated based on system specification . 

whatever the file we are tracking those files/folders are not added in gitingore.

https://github.com/chr56/Phonograph_Plus/issues/158#issuecomment-2173893685