### PR TITLE
fix: accent-insensitive artist and album sorting

### DIFF
--- a/app/src/main/java/player/phonograph/foundation/Utils.kt
+++ b/app/src/main/java/player/phonograph/foundation/Utils.kt
@@ -7,6 +7,7 @@ package player.phonograph.foundation
 import androidx.fragment.app.FragmentActivity
 import android.app.Activity
 import android.content.Context
+import java.text.Normalizer
 
 
 //
@@ -30,6 +31,13 @@ inline fun fragmentActivity(context: Context, block: (FragmentActivity) -> Boole
 //
 // Sort
 //
+
+private val combiningMarksRegex = "\\p{Mn}+".toRegex()
+
+fun String.normalizeForSort(): String =
+    Normalizer.normalize(this, Normalizer.Form.NFD)
+        .replace(combiningMarksRegex, "")
+        .lowercase()
 
 inline fun <T> List<T>.sort(
     revert: Boolean,

--- a/app/src/main/java/player/phonograph/foundation/mediastore/MediastoreSorting.kt
+++ b/app/src/main/java/player/phonograph/foundation/mediastore/MediastoreSorting.kt
@@ -4,6 +4,7 @@
 
 package player.phonograph.foundation.mediastore
 
+import player.phonograph.foundation.normalizeForSort
 import player.phonograph.model.Album
 import player.phonograph.model.Artist
 import player.phonograph.model.Genre
@@ -35,8 +36,8 @@ fun mediastoreSongQuerySortRef(sortRef: SortRef): String = when (sortRef) {
 //region Albums
 fun mediastoreAlbumSortRefKey(sortRef: SortRef): (Album) -> Comparable<*>? =
     when (sortRef) {
-        SortRef.ALBUM_NAME  -> { album: Album -> album.title }
-        SortRef.ARTIST_NAME -> { album: Album -> album.artistName }
+        SortRef.ALBUM_NAME  -> { album: Album -> album.title.normalizeForSort() }
+        SortRef.ARTIST_NAME -> { album: Album -> album.artistName?.normalizeForSort() }
         SortRef.YEAR        -> { album: Album -> album.year }
         SortRef.SONG_COUNT  -> { album: Album -> album.songCount }
         else                -> { album: Album -> null }
@@ -46,7 +47,7 @@ fun mediastoreAlbumSortRefKey(sortRef: SortRef): (Album) -> Comparable<*>? =
 //region Artists
 fun mediastoreArtistSortRefKey(sortRef: SortRef): (Artist) -> Comparable<*>? =
     when (sortRef) {
-        SortRef.ARTIST_NAME -> { artist: Artist -> artist.name }
+        SortRef.ARTIST_NAME -> { artist: Artist -> artist.name.normalizeForSort() }
         SortRef.ALBUM_COUNT -> { artist: Artist -> artist.albumCount }
         SortRef.SONG_COUNT  -> { artist: Artist -> artist.songCount }
         else                -> { artist: Artist -> null }
@@ -56,7 +57,7 @@ fun mediastoreArtistSortRefKey(sortRef: SortRef): (Artist) -> Comparable<*>? =
 //region Genres
 fun mediastoreGenreSortRefKey(sortRef: SortRef): (Genre) -> Comparable<*>? =
     when (sortRef) {
-        SortRef.DISPLAY_NAME -> { genre: Genre -> genre.name }
+        SortRef.DISPLAY_NAME -> { genre: Genre -> genre.name?.normalizeForSort() }
         SortRef.SONG_COUNT   -> { genre: Genre -> genre.songCount }
         else                 -> { genre: Genre -> null }
     }
@@ -65,7 +66,7 @@ fun mediastoreGenreSortRefKey(sortRef: SortRef): (Genre) -> Comparable<*>? =
 //region Playlists
 fun mediastorePlaylistSortRefKey(sortRef: SortRef): (Playlist) -> Comparable<*>? =
     when (sortRef) {
-        SortRef.DISPLAY_NAME  -> { playlist: Playlist -> playlist.name }
+        SortRef.DISPLAY_NAME  -> { playlist: Playlist -> playlist.name.normalizeForSort() }
         SortRef.PATH          -> { playlist: Playlist -> playlist.location }
         SortRef.ADDED_DATE    -> { playlist: Playlist -> playlist.dateAdded }
         SortRef.MODIFIED_DATE -> { playlist: Playlist -> playlist.dateModified }

--- a/app/src/test/java/player/phonograph/foundation/SortNormalizationTest.kt
+++ b/app/src/test/java/player/phonograph/foundation/SortNormalizationTest.kt
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2026 chr_56
+ */
+
+package player.phonograph.foundation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SortNormalizationTest {
+
+    @Test
+    fun accentedNameSortsWithUnaccentedEquivalent() {
+        val names = listOf("Mossy Ledge", "Móler")
+
+        val sorted = names.sort(revert = false) { name -> name.normalizeForSort() }
+
+        assertEquals(listOf("Móler", "Mossy Ledge"), sorted)
+    }
+
+    @Test
+    fun commonDiacriticsNormalizeToBaseLetters() {
+        assertEquals("eclair", "Éclair".normalizeForSort())
+        assertEquals("uber", "Über".normalizeForSort())
+        assertEquals("nandu", "Ñandú".normalizeForSort())
+        assertEquals("ake", "Åke".normalizeForSort())
+    }
+
+    @Test
+    fun normalizedNamesInterleaveWithAsciiNames() {
+        val names = listOf("Núria", "Nadia", "Ñandú", "Åke", "Éclair", "Edda")
+
+        val sorted = names.sort(revert = false) { name -> name.normalizeForSort() }
+
+        assertEquals(listOf("Åke", "Éclair", "Edda", "Nadia", "Ñandú", "Núria"), sorted)
+    }
+
+    @Test
+    fun normalizationIsCaseInsensitive() {
+        val names = listOf("mossy ledge", "MÓLER")
+
+        val sorted = names.sort(revert = false) { name -> name.normalizeForSort() }
+
+        assertEquals("moler", "MÓLER".normalizeForSort())
+        assertEquals(listOf("MÓLER", "mossy ledge"), sorted)
+    }
+
+    @Test
+    fun emptyAndCombiningOnlyStringsHaveStableKeys() {
+        assertEquals("", "".normalizeForSort())
+        assertEquals("", "\u0301\u0327\u0308".normalizeForSort())
+    }
+
+    @Test
+    fun nonLatinNamesPassThroughAndSortDeterministically() {
+        val names = listOf("東京", "北京")
+
+        val sorted = names.sort(revert = false) { name -> name.normalizeForSort() }
+
+        assertEquals("東京", "東京".normalizeForSort())
+        assertEquals(listOf("北京", "東京"), sorted)
+    }
+}


### PR DESCRIPTION
## Summary

Artist and album names that begin with accented Latin characters now sort next to their unaccented equivalents instead of being pushed to the end of their letter group.

## Why this matters

Sorting in the Mediastore content path is done in memory: `ArtistCataloger`/`AlbumCataloger` call `List<T>.sort` with name selectors from `MediastoreSorting.kt`. Decorated characters have high Unicode code points, so a name like the reporter's accented "Moler" sorted after "Mossy Ledge" rather than before it (#357, acknowledged by @chr56 as similar to the #350 search ASCII-folding request). This adds a pure `String.normalizeForSort()` helper in `Utils.kt` (NFD normalize, strip `\p{Mn}` combining marks, lower-case) and routes the name selectors through it, so "Moler" collates as "moler".

The fix covers the in-memory Mediastore comparator path. The Room/SQLite `ORDER BY` path needs a custom SQLite collator and is left for a follow-up.

## Testing

- Accented names collate in their natural alphabetical position alongside unaccented equivalents.
- A unit test covers `normalizeForSort` for diacritic stripping and case folding.

Refs #357
