### PR TITLE
Android 6 support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,7 @@ android {
     namespace = "player.phonograph"
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 23
         targetSdk = 36
 
         applicationId = "player.phonograph.plus"
@@ -131,7 +131,7 @@ android {
             resValue("string", "app_name", "$appName Checkout")
             applicationIdSuffix = ".checkout"
 
-            minSdk = 24
+            minSdk = 23
 
             manifestPlaceholders["GIT_COMMIT_HASH"] = getGitHash(false) ?: "n/a"
         }
@@ -146,7 +146,7 @@ android {
             matchingFallbacks.add("modern")
 
             targetSdk = 28
-            minSdk = 24
+            minSdk = 23
         }
 
     }

--- a/app/src/main/java/player/phonograph/foundation/localization/ContextLocaleDelegate.kt
+++ b/app/src/main/java/player/phonograph/foundation/localization/ContextLocaleDelegate.kt
@@ -14,6 +14,7 @@ import android.content.res.Configuration
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.TIRAMISU
 import java.util.Locale
+import android.os.Build
 
 object ContextLocaleDelegate {
 
@@ -50,7 +51,12 @@ object ContextLocaleDelegate {
 
     private fun registerSystemLocale(context: Context) {
         if (firstLocaleInit) {
-            startupLocale = context.resources.configuration.locales[0]
+            startupLocale = if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
+                context.resources.configuration.locales[0]
+            } else {
+                @Suppress("DEPRECATION")
+                context.resources.configuration.locale
+            }
             firstLocaleInit = false
         }
     }

--- a/app/src/main/java/player/phonograph/mechanism/metadata/read/JAudioTaggerExtractorImpl.kt
+++ b/app/src/main/java/player/phonograph/mechanism/metadata/read/JAudioTaggerExtractorImpl.kt
@@ -149,7 +149,7 @@ object ID3v2Readers {
                 ID3v24FieldKey.entries.firstOrNull { id == it.frameId }?.name ?: id
 
             override fun queryDescription(id: String): String? =
-                ID3v24Frames.getInstanceOf().idToValueMap?.getOrDefault(id, null)
+                ID3v24Frames.getInstanceOf().idToValueMap?.get(id)
 
             override fun isCustomKey(id: String): Boolean = id == ID3v24Frames.FRAME_ID_USER_DEFINED_INFO
 
@@ -160,7 +160,7 @@ object ID3v2Readers {
                 ID3v23FieldKey.entries.firstOrNull { id == it.frameId }?.name ?: id
 
             override fun queryDescription(id: String): String? =
-                ID3v23Frames.getInstanceOf().idToValueMap?.getOrDefault(id, null)
+                ID3v23Frames.getInstanceOf().idToValueMap?.get(id)
 
             override fun isCustomKey(id: String): Boolean = id == ID3v23Frames.FRAME_ID_V3_USER_DEFINED_INFO
         }
@@ -170,7 +170,7 @@ object ID3v2Readers {
                 ID3v22FieldKey.entries.firstOrNull { id == it.frameId }?.name ?: id
 
             override fun queryDescription(id: String): String? =
-                ID3v22Frames.getInstanceOf().idToValueMap?.getOrDefault(id, null)
+                ID3v22Frames.getInstanceOf().idToValueMap?.get(id)
 
             override fun isCustomKey(id: String): Boolean = id == ID3v22Frames.FRAME_ID_V2_USER_DEFINED_INFO
         }

--- a/app/src/main/java/player/phonograph/model/version/Version.kt
+++ b/app/src/main/java/player/phonograph/model/version/Version.kt
@@ -6,6 +6,7 @@ package player.phonograph.model.version
 
 import androidx.annotation.Keep
 import android.content.res.Resources
+import android.os.Build
 import android.os.Parcelable
 import android.text.Html
 import android.text.Spanned
@@ -41,7 +42,10 @@ data class Version(
         val zh_cn: String = "",
     ) : Parcelable {
         fun parsed(resources: Resources): Spanned {
-            val lang = resources.configuration.locales.get(0)
+            val lang = if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {resources.configuration.locales.get(0)} else {
+                @Suppress("DEPRECATION")
+                resources.configuration.locale
+            }
             val source = if (lang.language.lowercase() == "zh") zh_cn else en
             return Html.fromHtml(source, Html.FROM_HTML_MODE_LEGACY)
         }

--- a/app/src/main/java/player/phonograph/repo/mediastore/MediaStoreSongCollections.kt
+++ b/app/src/main/java/player/phonograph/repo/mediastore/MediaStoreSongCollections.kt
@@ -40,7 +40,7 @@ object MediaStoreSongCollections {
         // convert
         return grouped.map { (folder, songs) ->
             SongCollection(
-                name = shortNames.getOrDefault(folder, "Unknown"),
+                name = shortNames[folder]?: "Unknown",
                 songs = songs,
                 detail = folder
             )

--- a/app/src/main/java/player/phonograph/service/MusicService.kt
+++ b/app/src/main/java/player/phonograph/service/MusicService.kt
@@ -36,6 +36,7 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.media.audiofx.AudioEffect
 import android.os.Binder
+import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.os.Handler
@@ -406,7 +407,12 @@ class MusicService : MediaBrowserServiceCompat(),
             if (controller.playerState != PlayerState.PLAYING) {
                 when (controller.pauseReason) {
                     PauseReason.PAUSE_BY_MANUAL_ACTION, PauseReason.PAUSE_FOR_QUEUE_ENDED, PauseReason.PAUSE_ERROR,
-                        -> stopForeground(STOP_FOREGROUND_DETACH)
+                        -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                        stopForeground(STOP_FOREGROUND_DETACH)
+                    } else {
+                        @Suppress("DEPRECATION")
+                        stopForeground(false)
+                    }
                 }
             }
         }

--- a/app/src/main/java/player/phonograph/service/notification/PlayingNotificationManager.kt
+++ b/app/src/main/java/player/phonograph/service/notification/PlayingNotificationManager.kt
@@ -183,7 +183,12 @@ class PlayingNotificationManager : ServiceComponent {
                     notificationManager.notify(NOTIFICATION_ID, notification)
                     when (service.playerState) {
                         PLAYING, PAUSED    -> service.startForeground(NOTIFICATION_ID, notification)
-                        STOPPED, PREPARING -> service.stopForeground(STOP_FOREGROUND_DETACH)
+                        STOPPED, PREPARING -> if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
+                            service.stopForeground(STOP_FOREGROUND_DETACH)
+                        } else {
+                            @Suppress("DEPRECATION")
+                            service.stopForeground(false)
+                        }
                     }
                 }
             }
@@ -196,7 +201,12 @@ class PlayingNotificationManager : ServiceComponent {
 
     @Synchronized
     private fun removeNotification() {
-        service.stopForeground(STOP_FOREGROUND_REMOVE)
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
+            service.stopForeground(STOP_FOREGROUND_REMOVE)
+        } else {
+            @Suppress("DEPRECATION")
+            service.stopForeground(true)
+        }
         notificationManager.cancel(NOTIFICATION_ID)
     }
 

--- a/app/src/main/java/player/phonograph/ui/adapter/DisplayPresenters.kt
+++ b/app/src/main/java/player/phonograph/ui/adapter/DisplayPresenters.kt
@@ -33,6 +33,8 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.getSystemService
 import android.content.Context
 import android.graphics.drawable.Drawable
+import android.os.Build
+import android.os.Environment
 import android.os.storage.StorageManager
 
 abstract class SongBasicDisplayPresenter(
@@ -274,9 +276,13 @@ abstract class SongCollectionBasicDisplayPresenter(
         }
 
         private val internalStorageRootPath: String by lazy {
-            val storageManager = App.instance.getSystemService<StorageManager>()!!
-            val storageVolume = storageManager.primaryStorageVolume
-            storageVolume.rootDirectory()?.absolutePath ?: ""
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
+                val storageManager = App.instance.getSystemService<StorageManager>()!!
+                storageManager.primaryStorageVolume.rootDirectory()?.absolutePath ?: ""
+            } else {
+                @Suppress("DEPRECATION")
+                Environment.getExternalStorageDirectory().absolutePath
+            }
         }
     }
 }

--- a/app/src/main/java/player/phonograph/ui/modules/setting/elements/NowPlayingScreenStyle.kt
+++ b/app/src/main/java/player/phonograph/ui/modules/setting/elements/NowPlayingScreenStyle.kt
@@ -143,7 +143,7 @@ private fun PlayerControllerButtonFunctions(
         stringResource(R.string.player_controller_function_queue_mode_alternative),
     )
     for ((buttonOrder, buttonId) in AllButtons.withIndex()) {
-        val function = current.buttons.getOrDefault(buttonId, -1)
+        val function = current.buttons[buttonId]?: -1
         val selectedFunction = AllButtonFunctions.indexOf(function).coerceIn(0, AllButtonFunctions.size)
         val title = stringResource(R.string.player_controller_designate_button_functions, buttonNames[buttonOrder])
         val description = buttonDescriptions[buttonOrder]

--- a/app/src/main/java/player/phonograph/ui/modules/upgrade/UpgradeInfoDialog.kt
+++ b/app/src/main/java/player/phonograph/ui/modules/upgrade/UpgradeInfoDialog.kt
@@ -188,7 +188,7 @@ private fun VersionTitle(version: Version, highlight: Boolean = false, modifier:
 }
 
 private fun channelColor(channel: String) =
-    Color(channelColors.getOrDefault(channel, MaterialColor.BlueGrey._700.asColor))
+    Color(channelColors[channel]?: MaterialColor.BlueGrey._700.asColor)
 
 private val channelColors: Map<String, Int>
     get() = mapOf(


### PR DESCRIPTION
I am a long-time user of Phonograph Plus, but unfortunately it does not support older Android devices.

I suppose that asking support for older device might come as a surprise, but I have some older Android 6 device that work perfectly, except that finding application is harder.
In particular I did not find a music player I liked.

I tried to compile the code with `minSdk = 23`, and fixed the crashes I encountered.

There might still be other places where Phonograph Plus does not work correctly on an Android 6 device, but so far, it worked for me without issues (starting application, changing some default settings, playing music).

Even if support is not complete, I would be more than happy if Phonograph Plus would support Android 6 as best-effort, especially considering that not many changes where necessary for having a working application
